### PR TITLE
use multi-category instead of consult-multi

### DIFF
--- a/all-the-icons-completion.el
+++ b/all-the-icons-completion.el
@@ -79,12 +79,12 @@ PROP is the property which is looked up."
       (let ((cat (funcall orig metadata 'category))
             (aff (funcall orig metadata 'affixation-function)))
         (cond
-         ((and (eq cat 'consult-multi) aff)
+         ((and (eq cat 'multi-category) aff)
           (lambda (cands)
             (mapcar (lambda (x)
                       (pcase-exhaustive x
                         (`(,cand ,prefix ,suffix)
-                         (let ((orig (get-text-property 0 'consult-multi cand)))
+                         (let ((orig (get-text-property 0 'multi-category cand)))
                            (list cand
                                  (concat (all-the-icons-completion-get-icon (cdr orig) (car orig))
                                          prefix)
@@ -95,16 +95,16 @@ PROP is the property which is looked up."
             (mapcar (lambda (x)
                       (pcase-exhaustive x
                         (`(,cand ,prefix ,suffix)
-                         (let ((orig (get-text-property 0 'consult-multi cand)))
+                         (let ((orig (get-text-property 0 'multi-category cand)))
                            (list cand
                                  (concat (all-the-icons-completion-get-icon cand cat)
                                          prefix)
                                  suffix)))))
                     (funcall aff cands))))
-         ((eq cat 'consult-multi)
+         ((eq cat 'multi-category)
           (lambda (cands)
             (mapcar (lambda (x)
-                      (let ((orig (get-text-property 0 'consult-multi x)))
+                      (let ((orig (get-text-property 0 'multi-category x)))
                         (list x (all-the-icons-completion-get-icon (cdr orig) (car orig)) "")))
                     cands)))
          (cat


### PR DESCRIPTION
Some consult commands (for example consult-buffer) no longer display icons with last version of consult from git repo.

The cause is the replacement of `consult-multi` by `multi-category` in marginalia https://github.com/minad/marginalia/pull/119, consult https://github.com/minad/consult/pull/488 and embark https://github.com/oantolin/embark/pull/440

This PR fix the problem (at least for me).