### PR TITLE
Find icons for file candidates containing a path prefix.

### DIFF
--- a/all-the-icons-completion.el
+++ b/all-the-icons-completion.el
@@ -58,7 +58,7 @@
          (concat
           (all-the-icons-icon-for-dir cand :face 'all-the-icons-completion-dir-face)
           " "))
-        (t (concat (all-the-icons-icon-for-file cand) " "))))
+        (t (concat (all-the-icons-icon-for-file (file-name-nondirectory cand)) " "))))
 
 (cl-defmethod all-the-icons-completion-get-icon (cand (_cat (eql project-file)))
   "Return the icon for the candidate CAND of completion category project-file."


### PR DESCRIPTION
Certain functions (e.g., `project-find-files`) will produce a candidate list where each candidate may contain a path prefix (e.g., "docs/Makefile").  This is problematic when invoking `all-the-icons-icon-for-file` as it is expecting a filename, not a path.  Some regular expressions in `all-the-icons-regexp-icon-alist` expect to match against the entire filename (e.g., "^Makefile$") and will fail to match when a path prefix is present.  This change strips any path prefix before invoking `all-the-icons-icon-for-file`.